### PR TITLE
Improved implementation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'rubydns'
 gem 'pry'
-gem 'activesupport'
+
+gem 'async-dns'
+gem 'async-http'

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'pry'
 
-gem 'async-dns'
+gem 'async-dns', '~> 1.2'
 gem 'async-http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     async (1.8.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-dns (1.1.1)
+    async-dns (1.2.0)
       async-io (~> 1.3)
     async-http (0.24.1)
       async (~> 1.6)
@@ -20,8 +20,6 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rubydns (2.0.1)
-      async-dns (~> 1.0)
     timers (4.1.2)
       hitimes
 
@@ -29,10 +27,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  async-dns
+  async-dns (~> 1.2)
   async-http
   pry
-  rubydns
 
 BUNDLED WITH
    1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    async (1.6.0)
-      nio4r (~> 2.0)
+    async (1.8.0)
+      nio4r (~> 2.3)
       timers (~> 4.1)
-    async-dns (1.1.0)
+    async-dns (1.1.1)
       async-io (~> 1.3)
-    async-io (1.7.0)
+    async-http (0.24.1)
+      async (~> 1.6)
+      async-io (~> 1.12)
+      http-2 (~> 0.9.0)
+    async-io (1.12.0)
       async (~> 1.3)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
     hitimes (1.2.6)
-    i18n (1.0.1)
-      concurrent-ruby (~> 1.0)
+    http-2 (0.9.1)
     method_source (0.9.0)
-    minitest (5.11.3)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rubydns (2.0.1)
       async-dns (~> 1.0)
-    thread_safe (0.3.6)
     timers (4.1.2)
       hitimes
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  async-dns
+  async-http
   pry
   rubydns
 

--- a/server.rb
+++ b/server.rb
@@ -1,33 +1,66 @@
 #!/usr/bin/env ruby
-require 'rubydns'
-require 'uri'
-require 'pry'
-require 'active_support'
-require 'active_support/core_ext'
-require 'open-uri'
 
-INTERFACES = [
-  [:udp, '0.0.0.0', 53],
-  [:tcp, '0.0.0.0', 53]
-]
+require 'json'
 
-RubyDNS::run_server(INTERFACES) do
-  otherwise do |t|
-    type = t.resource_class.to_s
+require 'async'
+
+require 'async/dns'
+
+require 'async/io/host_endpoint'
+
+require 'async/http/url_endpoint'
+require 'async/http/reference'
+require 'async/http/client'
+
+# RubyDNS is implemented by this class.
+class Server < Async::DNS::Server
+  def initialize(*)
+    super
+    
+    # This will cache one or more open connections.
+    @endpoint = Async::HTTP::URLEndpoint.parse("https://cloudflare-dns.com/dns-query")
+    @client = Async::HTTP::Client.new(@endpoint)
+  end
+  
+  def process(name, resource_class, transaction)
+    type = resource_class.to_s
     type.slice!(0..26)
-    uri = URI.parse('https://cloudflare-dns.com/dns-query')
-    uri.query = { ct: 'application/dns-json', name: t.question.to_s, type: type }.to_param
-    begin
-      answers = JSON.parse(uri.read)['Answer']
-      if answers.present?
-        t.respond!(answers.last['data'])
-        puts "Req: #{t.question.to_s} Type: #{type} Ans: #{answers.last['data']}"
-      else
-        t.fail!(:NXDomain)
-        puts "!!CANNOT RESOLVE!! Req: #{t.question.to_s} Type: #{type}"
+    
+    # This generates the appropriate request URL:
+    reference = Async::HTTP::Reference.parse(@endpoint.url.path, {
+      ct: 'application/dns-json',
+      name: name,
+      type: type,
+    })
+    
+    response = @client.get(reference)
+    answers = JSON.parse(response.read)['Answer']
+    
+    if answers.any?
+      # this is a hack...
+      transaction.fail!(:NoError)
+      
+      answers.each do |answer|
+        if klass = Resolv::DNS::Resource.get_class(answer["type"], resource_class::ClassValue)
+          if klass < Resolv::DNS::Resource::DomainName
+            resource = klass.new(Resolv::DNS::Name.create(answer["data"]))
+          else
+            resource = klass.new(answer["data"])
+          end
+          
+          transaction.response.add_answer(answer["name"], answer["TTL"], resource)
+        end
       end
-    rescue
-      t.fail!(:NXDomain)
+    else
+      transaction.fail!(:NXDomain)
     end
   end
 end
+
+INTERFACES = [
+  [:udp, '0.0.0.0', 5300],
+  [:tcp, '0.0.0.0', 5300]
+]
+
+server = Server.new(INTERFACES)
+server.run

--- a/server.rb
+++ b/server.rb
@@ -37,8 +37,7 @@ class Server < Async::DNS::Server
     answers = JSON.parse(response.read)['Answer']
     
     if answers.any?
-      # this is a hack...
-      transaction.fail!(:NoError)
+      transaction.append_question!
       
       answers.each do |answer|
         if klass = Resolv::DNS::Resource.get_class(answer["type"], resource_class::ClassValue)


### PR DESCRIPTION
- Use `async-http` which connect using HTTP/2 and also use persistent connection to reduce latency. First request is around 120ms, second request is around 25ms.
- Directly use `async-dns` which is what RubyDNS implemented on top of. It's better except for one small hack which I will fix in `async-dns`.

To see more details about what's going on inside server, run like this:

```
RUBYOPT=-d ./server.rb
```

By using HTTP/2, only one connection is required to make many concurrent requests.